### PR TITLE
Grammar and Style Edits to APE0.rst

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -1,4 +1,4 @@
-The Astropy Project Bylaws
+The Astropy Project Governance
 ==========================
 
 author: The Astropy Governance Working Group: Tom Aldcroft, Matt Craig, Kelle Cruz, Lia Corrales, Steve Crawford, Nicole Foster, Pey Lian Lim, Stuart Mumford, Adrian Price-Whelan, Thomas Robitaille, David Shupe, Brigitta Sipocz, Erik Tollerud
@@ -15,34 +15,38 @@ status: Discussion
 
 Abstract
 ========
-This APE is a living document that defines the formal fundamental governance process for the Astropy Project. Governance is based around the election of a Coordination Committee. The Coordination Committee has broad authority, which they seek to exercise as rarely as possible by working towards consensus.
+This APE defines the formal fundamental governance process for the Astropy Project. The Astropy Project broadly follows the philosophy of do-ocracy: project participants who 
+gain experience and knowledge through sustained community contributions and have demonstrated adherence to core principles of inclusion and consensus-building will be entrusted 
+with increasing levels of authority. At its core, the Project is both by and for its community, so it is the final source of authority and direction.
 
-
-Detailed description
+Detailed Description
 ====================
-
-The bylaws are described in this section. The initial version is the outcome of several months of discussion by the Astropy Governance Working Group, which aimed to both codification of existing informal governance rules as well as update it with new ideas that are consistent with the philosophy of and vision for the Astropy project.
-
+The governance policies are described in this section. The initial version is the outcome of several months of discussion by the Astropy Governance Working Group, which aimed to both codify existing informal governance rules as well as update them with new ideas that are consistent with the philosophy of and vision for the Astropy project.
 
 Ultimate Authority: The Astropy Community
 -----------------------------------------
-At its core, the Astropy Project derives its authority from the whole community - developers, users, and even potential participants in the broader astronomical and scientific software community. All have a vested interest in the success of the Project, so all governance in the end belongs to this community in its entirety.  The governance bylaws described below provide levels of delegation of that authority, particularly to the voting members and the Coordination Committee.  The Astropy Project broadly follows the philosophy of do-ocracy: project participants who gain experience and knowledge through sustained community contributions and have demonstrated adherence to core principles of inclusion and consensus-building will be entrusted with increasing levels of authority. At its core, the Project is both by and for its community, so it is the final source of authority and direction.
+The Astropy Project derives its authority from the whole community - developers, users, and even potential participants in the broader astronomical and scientific software 
+community. All have a vested interest in the success of the Project, so all governance in the end belongs to this community in its entirety. The governance policies described 
+below provide levels of delegation of that authority, particularly to the Voting Members and the Coordination Committee. 
 
 The Coordination Committee
 --------------------------
 
 Composition
 ^^^^^^^^^^^
-The Coordination Committee is a committee that is composed of four members. To represent a broad set of interests, the Coordination Committee should have no more than two members from a particular employer. The Ombudsperson (described below) and Coordination Committee should work to maintain this composition following the processes laid out in these bylaws.
+The Coordination Committee is a committee that is composed of four members. To represent a broad set of interests, the Coordination Committee should have no more than two 
+members from a particular employer. The Ombudsperson (described in Section 4)  and the Coordination Committee will work to maintain this composition following the processes 
+laid out in these policies.
 
-Mandate
+Role
 ^^^^^^^
 The Coordination Committee’s role is to facilitate consensus in the Project and coordinate Project-spanning efforts.  As such, the Coordination Committee shall work to:
+
 * Maintain the quality and stability of the Astropy ecosystem of packages for the community,
 * Facilitate the development of resources that improve accessibility and understanding of the Astropy ecosystem,
 * Make contributing as accessible, inclusive, and sustainable as possible,
 * Oversee the financial and legal status of the project,
-* Lead and oversee the decision making process for APEs and other community decisions,
+* Lead and oversee the decision-making process for APEs and other community decisions,
 * Seek consensus among the Astropy community, particularly before acting in a formal capacity,
 * Act as the decision-making body where all other methods for achieving consensus have failed,
 * Operate openly and provide transparency and opportunity for community input into its activities.
@@ -50,55 +54,97 @@ The Coordination Committee’s role is to facilitate consensus in the Project an
 Powers
 ^^^^^^
 The Coordination Committee has broad authority to make decisions about the Project. For example, they can:
+
 * Accept or reject APEs;
 * Enforce or update the Project's code of conduct
 * Manage any project assets (including financial and physical assets)
 * Delegate parts of their authority to other subcommittees or processes
-However, they cannot modify the bylaws of the Project (i.e., this document), except via the mechanisms specified here.
-The Coordination Committee should look for ways to use these powers as little as possible, striving to involve the community whenever possible for decisions, and delegating powers.
 
-Making decisions
+However, they cannot modify the Governance of the Project (i.e., this document), except during the initial adoption of these policies as specified herein.
+
+The Coordination Committee has broad authority, which they seek to exercise as rarely as possible by working towards consensus. The Coordination Committee should look for ways 
+to use these powers as little as possible, striving to involve the community whenever possible for decisions, and delegating responsibilities.
+
+When delegating its power by creating roles or making appointments the Coordination Committee must solicit community feedback for no less than two weeks.
+
+Making Decisions
 ^^^^^^^^^^^^^^^^
-To use its powers, if consensus cannot be reached within the committee, the Coordination Committee votes. Every Coordination Committee member must either vote or explicitly abstain. Members with conflicts of interest on a particular vote must abstain. The final decision regarding what constitutes a conflict of interest in terms of serving on the Coordination Committee, during elections or individual votes is determined by the Ombudsperson in accordance with a published conflict of interest policy. Passing decisions requires a strict majority of non-abstaining Coordination Committee members.
-Whenever possible, the Coordination Committee's deliberations and votes shall be held in public in a manner which permits discussion and comments from the community.
+To use its powers, the Coordination Committee must first attempt to reach a consensus. If a consensus cannot be reached the Committee votes. Every Coordination Committee member 
+must either vote or explicitly abstain. Members with a conflict of interest on a particular vote must abstain. The final decision regarding what constitutes a conflict of 
+interest is determined by the Ombudsperson in accordance with the conflict of interest policy. Passing decisions require a strict majority of non-abstaining Coordination 
+Committee members.
+
+Whenever possible, the Coordination Committee's deliberations shall be held in public in a manner that permits discussion and comments from the community. Final decisions made 
+by the Coordination Committee will be published in a publicly visible location.
 
 Electing the Coordination Committee
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-A Coordination Committee election is held annually to fill any vacant seats. Notice of the election must be posted via the Project’s standard communication channels (reaching all active Voting Members) at least one month before the beginning of Phase 1.  The election consists of two phases, each lasting two weeks:
-* Phase 1: Candidates advertise their interest in serving. Candidates can be nominated by anyone, including self-nominations, and do not have to be Voting Members themselves. 
-* Phase 2: Each voting member can vote for zero or more of the candidates, up to the number of candidates. Voting is performed anonymously. Candidates are ranked by the total number of votes they receive. If a tie occurs, it may be resolved by mutual agreement among the candidates, or else the winner will be chosen at random.
-The election process is managed by a non-voting Returns Officer nominated by the outgoing Coordination Committee. For the initial election, the Returns Officer will be nominated by the NumFOCUS Executive officer or their delegate. Elections will be carried out every year, provided that at least one of the Coordination Committee members has reached the end of their term or decided to step down.
+A Coordination Committee election is held annually to fill any vacant seats. Notice of the election must be posted via the Project’s standard communication channels (reaching 
+all active s) at least one month before the election begins.  The election consists of two phases, each lasting two weeks:
+
+* Phase 1, Nominations: Candidates will be nominated and confirm their interest in serving. Candidates can be nominated by anyone, including themselves, and do not have to be  
+  Voting Members to be nominated. 
+* Phase 2, Voting: Each Voting Member can vote for zero or more of the candidates, up to the number of candidates. Voting is performed anonymously. Candidates are ranked by the 
+  total number of votes they receive. If a tie occurs, it may be resolved by mutual agreement among the candidates, or else the winner will be chosen at random.
+
+The election process is managed by a non-voting Returns Officer nominated by the outgoing Coordination Committee. For the initial election, the Returns Officer will be 
+nominated by the NumFOCUS Executive officer or their delegate. Elections will be carried out every year, provided that at least one of the Coordination Committee members has 
+reached the end of their term or decided to step down.
 
 Term
 ^^^^
-Each Coordination Committee member's term runs for three years from when the election results are finalized, except when the election was to fill a vacancy created part way through a term. In that case the newly-elected member’s term runs for the remainder of the term of the person they are replacing. There are no limits on the number of terms that a single individual can be elected for.
-For the initial election of Coordination Committee members, two seats will have terms of one year, one has a term of two years and one has a term of three years so as to create a staggered set of replacements and provide continuity in the Coordination Committee.
+Each Coordination Committee member's term runs for three years from when the election results are finalized, except when the election was to fill a vacancy created partway 
+through a term. In that case, the newly-elected member’s term runs for the remainder of the term of the person they are replacing. There is no limit to the number of terms that 
+a single individual can be elected for.
+
+For the initial election of Coordination Committee members, two seats will have terms of one year, one has a term of two years, and one has a term of three years to create a 
+staggered set of replacements and provide continuity in the Coordination Committee.
 
 Vacancies
 ^^^^^^^^^
 Coordination Committee members may resign their position at any time.
-Whenever there is a vacancy during the regular Coordination Committee term, the Coordination Committee must solicit nominations to fill the vacancy and an election must take place.
-If a Coordination Committee member cannot be contacted for longer than two months without prior notification (for example, due to planned leave), then the rest of the Coordination Committee may vote to trigger an election to replace them for the duration of their term.
+
+Whenever there is a vacancy during the regular Coordination Committee term an election must take place.
+
+If a Coordination Committee member cannot be contacted for longer than two months without prior notification (for example, due to planned leave), then the rest of the 
+Coordination Committee may vote to trigger an election to replace them for the duration of their term.
 
 Removing Members
 ^^^^^^^^^^^^^^^^
 In exceptional circumstances, the Voting Members may remove one or more sitting Coordination Committee members via a single vote.
-Such a vote is triggered when a Voting Member calls for one publicly on an appropriate Project-wide communication channel, and two other active Voting Members second the proposal.
-In order for the Coordination Committee Member(s) to be removed, 2/3 of the active Voting Members must vote in support of the removal.
-To avoid repeated removal votes, any individual Voting Member who has called for, or seconded such a vote, may not call for or second such a vote (against any Coordination Committee member) for one year from the original motion.
+
+Such a vote is triggered when a Voting Member calls for one publicly on an appropriate Project-wide communication channel, and two other active Voting Members second the 
+proposal.
+
+For Coordination Committee Member(s) to be removed, 2/3 of the active Voting Members must vote in support of the removal.
+
+To avoid repeated removal votes, any individual Voting Member who has called for, or seconded such a vote, may not call for or second a vote to remove any other Coordination 
+Committee member for one year from the original motion.
 
 The Ombudsperson
 ----------------
-The Ombudsperson represents the interests of the Astropy community by providing an alternative point of contact for sensitive issues such as code of conduct violations and ethical concerns. Candidates for this project role are publicly nominated by the Coordination Committee, after which the Coordination Committee allows at least 2 weeks for comment, and then the nominee must be confirmed by ⅔ of the active Voting Members.  The Ombudsperson has no term limit but can resign at any time, or be removed by the same process as being confirmed: the Coordination Committee initiates, there is a two-week comment period, and ⅔ of the active Voting Members have to approve the removal. In the period between removal/resignation and new appointment, the Coordination Committee will temporarily take over the responsibilities of the Ombudsperson, should the need arise.
+The Ombudsperson represents the interests of the Astropy community by providing an alternative point of contact for sensitive issues such as code of conduct violations and 
+ethical concerns. Candidates for this project role are publicly nominated by the Coordination Committee, after which the Coordination Committee allows at least 2 weeks for 
+comment, and then the nominee must be confirmed by ⅔ of the active Voting Members.  
+
+The Ombudsperson has no term limit but can resign at any time, or be removed by the same process as being confirmed: the Coordination Committee initiates, there is a two-week 
+comment period, and ⅔ of the active Voting Members have to approve the removal. In the period between removal/resignation and new appointment, the Coordination Committee will 
+temporarily take over the responsibilities of the Ombudsperson, should the need arise.
 
 The Voting Members
 ------------------
 
 Role
 ^^^^
-The Voting Membership is the group of trusted individuals who operate the Astropy Project on behalf of the community.  They have authority over the Astropy Project’s technical resources, including the Astropy Project website itself, the Astropy GitHub organization and repositories, the issue tracker, the mailing lists, chat channels, etc. In practice, this authority is passed to the Coordination Committee via the voting processes described in these bylaws.
-They also assume many roles required to achieve the Project's goals, especially those that require a high level of trust. Collectively, they are a group that makes the decisions that shape the future of the Project.  
-Voting Members are expected to act as role models for the community and custodians of the Project, on behalf of the community and all those who rely on Astropy. They will act as representatives of the Astropy Project, where necessary, in online discussions or at official Astropy events.
+The Voting Members are the group of trusted individuals who operate the Astropy Project on behalf of the community.  They have authority over the Astropy Project’s technical 
+resources, including the Astropy Project website itself, the Astropy GitHub organization and repositories, the issue tracker, and all Astropy communication channels. In 
+practice, much of this authority is passed to the Coordination Committee via the voting processes described in these policies.
+
+They also assume many roles required to achieve the Project's goals, especially those that require a high level of trust. Collectively, they make decisions that shape the 
+future of the Project.  
+
+Voting Members are expected to act as role models for the community and custodians of the Project, on behalf of the community and all those who rely on Astropy. They will act 
+as representatives of the Astropy Project, where necessary, including in online discussions or at official Astropy events.
 
 Powers
 ^^^^^^
@@ -108,91 +154,98 @@ Voting Members may participate in formal votes on:
 * electing Coordination Committee members,
 * removing Coordination Committee members,
 * appointment or removal of the Ombudsperson,
-* changes to these bylaws,
+* changes to these policies,
 * other matters for which the Coordination Committee believes a vote is appropriate.
-The mechanism, timeline, and criteria for a decisive  vote are specified in the respective sections of this document in the first six cases and by the Coordination Committee in the last case.
+
+The mechanism, timeline, and criteria for a decisive  vote are specified in the respective sections of this document in the first six cases and by the Coordination Committee in 
+the last case.
 
 Membership
 ^^^^^^^^^^
-Voting Members of the Astropy Project demonstrate:
+Voting Members of the Astropy Project must demonstrate:
 * a good grasp of the philosophy of the Astropy Project,
 * a solid track record of being constructive and helpful,
 * significant contributions to the Project's goals, in any form,
-* willingness to dedicate time to improving the Project,
+* a willingness to dedicate time to improving the Project,
 * a willingness to recruit, train, and nominate new team members.
-Voting membership acknowledges sustained and valuable efforts that align well with the philosophy and the goals of the Astropy Project.
 
-Initial membership
+Voting Membership acknowledges sustained and valuable efforts that align well with the philosophy and the goals of the Astropy Project.
+
+Initial Membership
 ^^^^^^^^^^^^^^^^^^
 Anyone who satisfies any of the following criteria will be invited to be in the first group of Voting Members: 
 
 * has a named role in the project and has participated in an Astropy coordination meeting in the last two years, 
-* has a named role in the project and has regularly participated in Astropy telecons (e.g., co-working telecon, spectroscopy sprint, Astropy Learn telecon) in the last two years, 
+* has a named role in the project and has regularly participated in Astropy telecons (e.g., co-working telecon, spectroscopy sprint, Astropy Learn telecon) in the last two   
+  years, 
 * has commit rights to at least one repository in the astropy GitHub organization and has actively used those commit rights in the last two years.
 
-Add new Voting Members
+Add New Voting Members
 ^^^^^^^^^^^^^^^^^^^^^^
-Anyone can apply to become a Voting Member by providing evidence of meeting the requirements laid out in the section 'Membership,' above. Both self-nominations and nominations by others are allowed. The Voting Members are expected to make their decisions based on the candidate’s adherence to the membership criteria, above. The name of the nominee will be known to Voting Members but will not be shared outside Voting Members and the Coordination Committee unless the nominee becomes a Voting Member.
+Anyone can apply to become a Voting Member by providing evidence of meeting the requirements laid out in the Membership section above. Both self-nominations and nominations by 
+others are allowed. The Voting Members are expected to make their decisions based on the candidate’s adherence to the membership criteria, above. The name of the nominee will 
+be known to Voting Members but will not be shared outside Voting Members and the Coordination Committee unless the nominee becomes a Voting Member.
 
+The procedure for voting to add new Voting Members is:
 
-The procedure for voting on new Voting Members is:
-
-
-* The Coordination Committee and Ombudsperson receives each nomination, checks that it is factually accurate, that the nominated person accepts the nomination, and that their record of community activity adheres to  the Code of Conduct.
-* Once a nomination is accepted by the Coordination Committee, the Coordination Committee will initiate a vote among active Voting Members. The voting will be open for at least two weeks and will conclude within four weeks of the nomination being accepted. To successfully gain appointment as a Voting Member, the nominee must receive at least four positive votes, as long as that constitutes a majority of those voting. 
-* The candidate will be informed promptly at the close of voting by a Coordination Committee member. If the vote is not affirmative, the Coordination Committee will provide feedback to the nominee.
+* The Coordination Committee and Ombudsperson receive each nomination, check that it is factually accurate, that the nominated person accepts the nomination, and that their 
+  record of community activity adheres to the Code of Conduct.
+* Once a nomination is accepted by the Coordination Committee, the Coordination Committee will initiate a vote among active Voting Members. The voting will be open for at least 
+  two weeks and will conclude within four weeks of the nomination being accepted. To successfully gain an appointment as a Voting Member, the nominee must receive at least four 
+  positive votes, as long as that constitutes a majority of those voting. 
+* The candidate will be informed promptly at the close of voting by a Coordination Committee member. If the vote is not affirmative, the Coordination Committee will provide 
+  feedback to the nominee.
 
 Term and Active/Inactive Status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Voting membership has no term limit. Voting members who have stopped contributing are encouraged to declare themselves as "inactive.” Those who have not made any non-trivial contribution for a long period of time may be asked to move themselves to the “inactive”  category by the Coordination Committee. If no response is received, the Coordination Committee may automatically change a Voting Member’s status to inactive. To record and honor their contributions, inactive Voting members will continue to be listed. Inactive Voting Members are not able to participate in votes.
+Voting Members have no term or term limits. Voting Members who have stopped contributing are encouraged to declare themselves as "inactive.” Those who have not made any 
+significant contribution for a long period may be asked to move themselves to the “inactive”  category by the Coordination Committee. If no response is received, the 
+Coordination Committee may automatically change a Voting Member’s status to inactive. To record and honor their contributions, inactive Voting Members will continue to be 
+listed. Inactive Voting Members are not able to participate in votes.
 
 Removing Voting Members
 ^^^^^^^^^^^^^^^^^^^^^^^
-In exceptional circumstances, it may be necessary to remove someone from the Voting Membership against their will. Such a vote is triggered by a motion made by an active Voting Member, which must be seconded by a second Voting Member. A vote must be held on removing the Voting Member, concluding no more than four weeks after the motion is seconded. Removal requires approval by ⅔ of all active Voting Members at the time the motion is made. The motion, second, and vote should all be private. A removal under this provision will be reflected by updating the list of Voting Members. 
-It may be necessary for the Ombudsperson and the Coordination Committee to remove a Voting Member for violations of the Code of Conduct. In this case, the Coordination Committee and Ombudsperson will work together to make this decision. 
+In exceptional circumstances, it may be necessary to remove someone from the Voting Members against their will. A vote must be held to remove a Voting Member. Such a vote is 
+triggered by a motion made by an active Voting Member, which must be seconded by an additional Voting Member. The vote must conclude  no more than four weeks after the motion 
+is seconded. Removal requires approval by ⅔ of all active Voting Members at the time the motion is made. The motion, second, and vote will be held in private. Removal under 
+this provision will be reflected by updating the list of Voting Members. 
 
+It may be necessary for the Ombudsperson and the Coordination Committee to remove a Voting Member for violations of the Code of Conduct. In this case, the Coordination 
+Committee and Ombudsperson will work together to make this decision. 
 
-Rules for creation and appointment of roles
--------------------------------------------
-Creation of and appointment to roles to which the Coordination Committee delegates its power must solicit community feedback for no less than two weeks.
-
-Approving and modifying these bylaws
+Approving and Modifying These Policies
 ------------------------------------
-This document was submitted following the process in APE 1, and the normal APE acceptance procedures will be followed. The Coordination Committee at the time of submitting this APE are all co-authors and therefore will not override any consensus of the community on accepting the final version.
-Changes to these bylaws after they have been accepted should follow the modification process in APE 1, with the exception that the final approval of the modification requires approval vote by ⅔ of the Voting Members rather than approval by the Coordination Committee. This should follow the same voting procedure as other votes in this document.
+This document was submitted following the process in APE 1, and the normal APE acceptance procedures will be followed. The Coordination Committee at the time of submitting this 
+APE are all co-authors and therefore will not override any consensus of the community on accepting the final version.
 
-
+Changes to these policies after they have been accepted should follow the modification process in APE 1, with the exception that the final approval of the modification requires 
+approval by a ⅔ vote of the Voting Members rather than approval by the Coordination Committee. 
 
 Attribution and Acknowledgements
 --------------------------------
-The format and some of the structures outlined in this document are heavily inspired by the Python Language Governance structure (`PEP13 <https://www.python.org/dev/peps/pep-0013/>`_), the YT Project's Team Infrastructure (`YTEP 1776 <https://ytep.readthedocs.io/en/latest/YTEPs/YTEP-1776.html>`_), and earlier less-formal descriptions of the Astropy governance.
+The format and some of the structures outlined in this document are heavily inspired by the Python Language Governance structure (`PEP13 <https://www.python.org/dev/peps/pep-
+0013/>`_), the YT Project's Team Infrastructure (`YTEP 1776 <https://ytep.readthedocs.io/en/latest/YTEPs/YTEP-1776.html>`_), and earlier less-formal descriptions of the Astropy 
+governance.
 
-
-Branches and pull requests
+Branches and Pull Requests
 ==========================
-
 N/A
-
 
 Implementation
 ==============
+These policies enter into force upon this APE being accepted (see the last section of the description).  At that time the ``GOVERNANCE.md`` file in the astropy repo should be 
+updated to point to this document.
 
-The bylaws enter into force upon this APE being accepted (see the last section of the description).  At that time the ``GOVERNANCE.md`` file in the astropy repo should be updated to point to this document.
-
-
-Backward compatibility
+Backward Compatibility
 ======================
-
-These bylaws supercede previous un-codified governance understandings, but do not serve to invalidate the APE process or any other processes or policies that pre-date it and do not conflict.
-
+These policies supercede previous un-codified governance understandings, but do not serve to invalidate the APE process or any other processes or policies that pre-date it and 
+do not conflict.
 
 Alternatives
 ============
-
-The Astropy Governance Working Group discussed a wide range of alternatives on both the broad scope of Project governance and details of these bylaws.  It is not practical to summarize that in the text of this APE, but the Working Group's running notes provide an excellent starting point for this discussion.
-
+The Astropy Governance Working Group discussed a wide range of alternatives on both the broad scope of Project governance and details of these policies.  It is not practical to 
+summarize that in the text of this APE, but the Working Group's running notes provide an excellent starting point for this discussion.
 
 Decision rationale
 ==================
-
 <To be filled in by the coordinating committee when the APE is accepted or rejected>

--- a/APE0.rst
+++ b/APE0.rst
@@ -1,11 +1,11 @@
-The Astropy Project Governance
-==========================
+The Astropy Project {bylaws-not-bylaws}
+=======================================
 
 author: The Astropy Governance Working Group: Tom Aldcroft, Matt Craig, Kelle Cruz, Lia Corrales, Steve Crawford, Nicole Foster, Pey Lian Lim, Stuart Mumford, Adrian Price-Whelan, Thomas Robitaille, David Shupe, Brigitta Sipocz, Erik Tollerud
 
 date-created: 2020 July 31
 
-date-last-revised: 2020 July 31
+date-last-revised: 2020 August 25
 
 date-accepted: <replace with accepted date>
 
@@ -21,12 +21,12 @@ with increasing levels of authority. This peaks with the Coordination Commitee, 
 
 Detailed Description
 ====================
-The governance policies are described in this section. The initial version is the outcome of several months of discussion by the Astropy Governance Working Group, which aimed to both codify existing informal governance rules as well as update them with new ideas that are consistent with the philosophy of and vision for the Astropy project.
+The {bylaws-not-bylaws} are described in this section. The initial version is the outcome of several months of discussion by the Astropy Governance Working Group, which aimed to both codify existing informal governance rules as well as update them with new ideas that are consistent with the philosophy of and vision for the Astropy project.
 
 Ultimate Authority: The Astropy Community
 -----------------------------------------
 The Astropy Project derives its authority from the whole community - developers, users, and even potential participants in the broader astronomical and scientific software 
-community. All have a vested interest in the success of the Project, so all governance in the end belongs to this community in its entirety. The governance policies described 
+community. All have a vested interest in the success of the Project, so all governance in the end belongs to this community in its entirety. The {bylaws-not-bylaws} described 
 below provide levels of delegation of that authority, particularly to the Voting Members and the Coordination Committee. 
 
 The Coordination Committee
@@ -36,7 +36,7 @@ Composition
 ^^^^^^^^^^^
 The Coordination Committee is a committee that is composed of four members. To represent a broad set of interests, the Coordination Committee should have no more than two 
 members from a particular employer. The Ombudsperson (described in Section 4)  and the Coordination Committee will work to maintain this composition following the processes 
-laid out in these policies.
+laid out in these {bylaws-not-bylaws}.
 
 Role
 ^^^^^^^
@@ -60,7 +60,7 @@ The Coordination Committee has broad authority to make decisions about the Proje
 * Manage any project assets (including financial and physical assets)
 * Delegate parts of their authority to other subcommittees or processes
 
-However, they cannot modify the Governance of the Project (i.e., this document), except during the initial adoption of these policies as specified herein.
+However, they cannot modify the Governance of the Project (i.e., this document), except during the initial adoption of these {bylaws-not-bylaws} as specified herein.
 
 The Coordination Committee has broad authority, which they seek to exercise as rarely as possible by working towards consensus. The Coordination Committee should look for ways 
 to use these powers as little as possible, striving to involve the community whenever possible for decisions, and delegating responsibilities.
@@ -138,7 +138,7 @@ Role
 ^^^^
 The Voting Members are the group of trusted individuals who operate the Astropy Project on behalf of the community.  They have authority over the Astropy Project’s technical 
 resources, including the Astropy Project website itself, the Astropy GitHub organization and repositories, the issue tracker, and all Astropy communication channels. In 
-practice, much of this authority is passed to the Coordination Committee via the voting processes described in these policies.
+practice, much of this authority is passed to the Coordination Committee via the voting processes described in these {bylaws-not-bylaws}.
 
 They also assume many roles required to achieve the Project's goals, especially those that require a high level of trust. Collectively, they make decisions that shape the 
 future of the Project.  
@@ -154,7 +154,7 @@ Voting Members may participate in formal votes on:
 * electing Coordination Committee members,
 * removing Coordination Committee members,
 * appointment or removal of the Ombudsperson,
-* changes to these policies,
+* changes to these {bylaws-not-bylaws},
 * other matters for which the Coordination Committee believes a vote is appropriate.
 
 The mechanism, timeline, and criteria for a decisive  vote are specified in the respective sections of this document in the first six cases and by the Coordination Committee in 
@@ -213,12 +213,12 @@ this provision will be reflected by updating the list of Voting Members.
 It may be necessary for the Ombudsperson and the Coordination Committee to remove a Voting Member for violations of the Code of Conduct. In this case, the Coordination 
 Committee and Ombudsperson will work together to make this decision. 
 
-Approving and Modifying These Policies
-------------------------------------
+Approving and Modifying These {bylaws-not-bylaws}
+-------------------------------------------------
 This document was submitted following the process in APE 1, and the normal APE acceptance procedures will be followed. The Coordination Committee at the time of submitting this 
 APE are all co-authors and therefore will not override any consensus of the community on accepting the final version.
 
-Changes to these policies after they have been accepted should follow the modification process in APE 1, with the exception that the final approval of the modification requires 
+Changes to these {bylaws-not-bylaws} after they have been accepted should follow the modification process in APE 1, with the exception that the final approval of the modification requires 
 approval by a ⅔ vote of the Voting Members rather than approval by the Coordination Committee. 
 
 Attribution and Acknowledgements
@@ -233,17 +233,17 @@ N/A
 
 Implementation
 ==============
-These policies enter into force upon this APE being accepted (see the last section of the description).  At that time the ``GOVERNANCE.md`` file in the astropy repo should be 
+These {bylaws-not-bylaws} enter into force upon this APE being accepted (see the last section of the description).  At that time the ``GOVERNANCE.md`` file in the astropy repo should be 
 updated to point to this document.
 
 Backward Compatibility
 ======================
-These policies supercede previous un-codified governance understandings, but do not serve to invalidate the APE process or any other processes or policies that pre-date it and 
+These {bylaws-not-bylaws} supercede previous un-codified governance understandings, but do not serve to invalidate the APE process or any other processes or policies that pre-date it and 
 do not conflict.
 
 Alternatives
 ============
-The Astropy Governance Working Group discussed a wide range of alternatives on both the broad scope of Project governance and details of these policies.  It is not practical to 
+The Astropy Governance Working Group discussed a wide range of alternatives on both the broad scope of Project governance and details of these {bylaws-not-bylaws}.  It is not practical to 
 summarize that in the text of this APE, but the Working Group's running notes provide an excellent starting point for this discussion.
 
 Decision rationale

--- a/APE0.rst
+++ b/APE0.rst
@@ -17,7 +17,7 @@ Abstract
 ========
 This APE defines the formal fundamental governance process for the Astropy Project. The Astropy Project broadly follows the philosophy of do-ocracy: project participants who 
 gain experience and knowledge through sustained community contributions and have demonstrated adherence to core principles of inclusion and consensus-building will be entrusted 
-with increasing levels of authority. At its core, the Project is both by and for its community, so it is the final source of authority and direction.
+with increasing levels of authority. This peaks with the Coordination Commitee, which has relatively broad authority but seeks to exercise it as rarely as possible by working towards consensus. This is because at its core, the Project is both by and for its community, and therefore it is the final source of authority and direction. 
 
 Detailed Description
 ====================


### PR DESCRIPTION
I worked from the perspective that I did not want to make any changes to the substance of these policies. If anyone feels that any of these edits change the meaning of any clause we should review thoroughly. The only change I did make was to remove the term "ByLaws" and replace it with "policies"  throughout the document. (Though this should not have much of an effect on the substance) This term cannot be used because it is a term with legal connotations for NumFOCUS.  "policies" can be changed to some other term if the community desires.